### PR TITLE
Svd fix

### DIFF
--- a/photo_wct.py
+++ b/photo_wct.py
@@ -131,10 +131,13 @@ class PhotoWCT(nn.Module):
             iden = iden.cuda(self.device)
         
         contentConv = torch.mm(cont_feat, cont_feat.t()).div(cFSize[1] - 1) + iden
+        
         # del iden
-        c_u, c_e, c_v = torch.svd(contentConv, some=False)
-        # c_e2, c_v = torch.eig(contentConv, True)
-        # c_e = c_e2[:,0]
+        try:
+            c_u, c_e, c_v = torch.svd(contentConv, some=False)
+        except RuntimeError:
+            c_e2, c_v = torch.eig(contentConv, True)
+            c_e = c_e2[:,0]
         
         k_c = cFSize[0]
         for i in range(cFSize[0] - 1, -1, -1):

--- a/photo_wct.py
+++ b/photo_wct.py
@@ -149,7 +149,12 @@ class PhotoWCT(nn.Module):
         s_mean = torch.mean(styl_feat, 1)
         styl_feat = styl_feat - s_mean.unsqueeze(1).expand_as(styl_feat)
         styleConv = torch.mm(styl_feat, styl_feat.t()).div(sFSize[1] - 1)
-        s_u, s_e, s_v = torch.svd(styleConv, some=False)
+
+        try:
+            s_u, s_e, s_v = torch.svd(styleConv, some=False)
+        except RuntimeError:
+            s_e2, s_v = torch.eig(styleConv, True)
+            s_e = s_e2[:,0]
         
         k_s = sFSize[0]
         for i in range(sFSize[0] - 1, -1, -1):


### PR DESCRIPTION
This PR provides a fall back for `torch.svd`, which often fails when stylizing images with segmentation masks. The fallback is to just use `torch.eig` for decomposition. 